### PR TITLE
Update mailstation.js

### DIFF
--- a/lib/rpc-client/mailstation.js
+++ b/lib/rpc-client/mailstation.js
@@ -338,6 +338,7 @@ pro.connect = function(tracer, serverId, cb) {
         mbox.close();
         delete self.mailboxes[id];
       }
+      self.emit('close', id);
     });
     delete self.connecting[serverId];
     flushPending(tracer, self, serverId);

--- a/lib/rpc-client/mailstation.js
+++ b/lib/rpc-client/mailstation.js
@@ -225,7 +225,7 @@ pro.dispatch = function(tracer, serverId, msg, opts, cb) {
     if(!lazyConnect(tracer, this, serverId, this.mailboxFactory, cb)) {
       tracer.error('client', __filename, 'dispatch', 'fail to find remote server:' + serverId);
       logger.error('[pomelo-rpc] fail to find remote server:' + serverId);
-      this.emit('error', constants.RPC_ERROR.NO_TRAGET_SERVER, tracer, serverId, msg, opts);
+      slef.emit('error', constants.RPC_ERROR.NO_TRAGET_SERVER, tracer, serverId, msg, opts);
     }
     // push request to the pending queue
     addToPending(tracer, this, serverId, Array.prototype.slice.call(arguments, 0));


### PR DESCRIPTION
缺少這句的話 有個mailstation單元測試不過
'#close' 'should emit a close event for each mailbox close'