### PR TITLE
这才是归宿啊

### DIFF
--- a/lib/rpc-client/failureProcess.js
+++ b/lib/rpc-client/failureProcess.js
@@ -18,7 +18,7 @@ module.exports = function(code, tracer, serverId, msg, opts) {
     break;
     case constants.FAIL_MODE.FAILSAFE:
     default:
-      method = failsafe;
+      method = failfast;
     break;
   }
   method.call(this, code, tracer, serverId, msg, opts, cb);


### PR DESCRIPTION
原来那样挺好，更新了这个后差点被坑，failsafe现在是有bug的，具体我没去找，反正多失败几次就会崩溃。不过这不是最主要的，最主要的是，这个失败了一般是场景那边异常了，exception了，根本不会再返回了，这边多次重试是非常不好的，而且，这边重试完全没有考虑过客户端的感受，失败了及时的返回错误给客户端，不要让人一直等才是最好的体验，而且如果要重试，客户端重新点也比这边好，这边这么做会导致客户端长时间没应答，这个体验非常糟糕
