### PR TITLE
fix sys namespace lost when remote reload

### DIFF
--- a/lib/rpc-server/dispatcher.js
+++ b/lib/rpc-server/dispatcher.js
@@ -6,7 +6,7 @@ var Dispatcher = function(services) {
   EventEmitter.call(this);
   var self = this;
   this.on('reload', function(services) {
-    self.services = services;
+    self.services.user = services.user;
   });
   this.services = services;
 };


### PR DESCRIPTION
修复：触发remote reload时，services更新时会丢失sys的接口
考虑到热更只需要热更用户代码，因此直接通过赋值新的 user namepace就行